### PR TITLE
Upgraded spritesmith version to 0.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "tasks/grunt-sprite-generator.js",
   "dependencies": {
-    "spritesmith": "0.10.0"
+    "spritesmith": "0.19.2"
   },
   "devDependencies": {
     "grunt": ">=0.4.1",


### PR DESCRIPTION
Added pngsmith as an engine, it make spritesmith work without phantomjs, gm , canvas engine.
phantomjs, gm , canvas engine have to install manual, but pngsmith engine will be installed by "npm install"

https://github.com/Ensighten/spritesmith/commit/215c11b23f084128e4865d610e93fad38fb546e0
