### PR TITLE
Replacing the background-image end computed URL

### DIFF
--- a/tasks/spriteGenerator.js
+++ b/tasks/spriteGenerator.js
@@ -118,7 +118,10 @@ module.exports = function(grunt) {
             var data = grunt.file.read(filepath);
 
             arr.forEach(function(obj) {
-                spritePath = spritePath.replace(options.endUrlPatternToReplace, options.endUrlPatternReplacer);
+                if (typeof options.endUrlPatternToReplace === 'string' &&
+                        typeof options.endUrlPatternReplacer === 'string') {
+                    spritePath = spritePath.replace(options.endUrlPatternToReplace, options.endUrlPatternReplacer);
+                }
                 data = data.replace(obj.ref, 'background-image: url(\''+ spritePath +'\');\n    background-position: -'+ obj.coords.x +'px -'+ obj.coords.y +'px;');
             });
 

--- a/tasks/spriteGenerator.js
+++ b/tasks/spriteGenerator.js
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  */
 
-var path 		= require('path');
+var path        = require('path');
 var spritesmith = require('spritesmith');
 
 module.exports = function(grunt) {
@@ -56,9 +56,9 @@ module.exports = function(grunt) {
                         var imagePath = file.match(filepathRegex)[0].replace(/['"]/g, '');
     
                         if(imagePath[0] === '/') {
-                        	filepath = options.baseUrl + imagePath;
+                            filepath = options.baseUrl + imagePath;
                         } else {
-                        	filepath = path.resolve(srcFile.substring(0, srcFile.lastIndexOf("/")), imagePath);
+                            filepath = path.resolve(srcFile.substring(0, srcFile.lastIndexOf("/")), imagePath);
                         }
     
                         if (grunt.file.exists(filepath)) {
@@ -118,6 +118,7 @@ module.exports = function(grunt) {
             var data = grunt.file.read(filepath);
 
             arr.forEach(function(obj) {
+                spritePath = spritePath.replace(options.endUrlPatternToReplace, options.endUrlPatternReplacer);
                 data = data.replace(obj.ref, 'background-image: url(\''+ spritePath +'\');\n    background-position: -'+ obj.coords.x +'px -'+ obj.coords.y +'px;');
             });
 


### PR DESCRIPTION
Sometimes, depending on your project needs, you need to specify different relative routes for your frontend application.

In my case, I needed to replace the end computed URL by a relative path where the images/ folder belongs to.

The only thing you would need to do, it's just to specify two parameters on the grunt job options, which coexist all together to work properly, which are 'endUrlPatternToReplace' and 'endUrlPatternReplacer':

```
spriteGenerator: {
      options: {
        algorithm: 'binary-tree',
        endUrlPatternToReplace: 'app/',
        endUrlPatternReplacer: '../',
        padding: 0
      },
      default_task: {
        files: {
          'app/images/sprites.png': ['./app/css/main.css']
        }
      }
    },
```

So, all URL embedded into the background-image of your source CSS file will be generated by replacing 'app/' by '../', which are the two options informed here.

I find this quite useful considering it's very difficult up to now to configure your job with different relative paths setups (I spent like two days trying to solve this problem out).
