### PR TITLE
Updated spritesmith dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "tasks/grunt-sprite-generator.js",
   "dependencies": {
-    "spritesmith": "0.10.0"
+    "spritesmith": "^1.3.1"
   },
   "devDependencies": {
     "grunt": ">=0.4.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "tasks/grunt-sprite-generator.js",
   "dependencies": {
-    "spritesmith": "^1.3.1"
+    "spritesmith": "~1.3.1"
   },
   "devDependencies": {
     "grunt": ">=0.4.1",


### PR DESCRIPTION
Updating to this version of `spritesmith` doesn't break `grunt-sprite-generator`, and it adds support to the `pixelsmith` engine, which doesn't rely neither on `cairo` nor `gm`, which makes it easier to install using simply npm.
